### PR TITLE
feat: package as Claude Code plugin with SkillShield badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Agent Decision Records (AgDR)
 
+[![SkillShield](https://skillshield.io/api/v1/badge/1daff16083a7aeed.svg)](https://skillshield.io/report/1daff16083a7aeed)
+
 **A standard for documenting technical decisions made by AI coding agents.**
 
 AgDR extends the proven [Architecture Decision Record](https://github.com/joelparkerhenderson/architecture-decision-record) (ADR) format for AI-assisted software development. When AI agents make technical choices—selecting libraries, choosing patterns, designing architecture—those decisions need the same rigor and traceability as human decisions.


### PR DESCRIPTION
## Summary
- Package AgDR as a Claude Code plugin with marketplace metadata for registry listing
- Add `/decide` slash command and skill definition for Claude Code integration
- Add SkillShield validation badge to README

## Test plan
- [ ] Verify plugin.json and marketplace.json are valid JSON
- [ ] Verify `/decide` command works in Claude Code
- [ ] Verify SkillShield badge renders correctly on README

