### PR TITLE
feat(codex): add AgDR Codex skill integration and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AgDR extends the proven [Architecture Decision Record](https://github.com/joelpa
 
 ## Why AgDR?
 
-AI coding agents (Claude Code, GitHub Copilot, Cursor, Windsurf, etc.) increasingly make technical decisions autonomously. Without documentation:
+AI coding agents (Claude Code, Codex, GitHub Copilot, Cursor, Windsurf, etc.) increasingly make technical decisions autonomously. Without documentation:
 
 - **Decisions are invisible** - No record of why the agent chose React over Vue
 - **Context is lost** - Next session starts fresh with no memory
@@ -32,6 +32,12 @@ AgDR solves this by requiring agents to document decisions in a structured, huma
 
 ```bash
 /decide which testing framework to use
+```
+
+### Using Codex
+
+```text
+$agdr-decide which testing framework to use
 ```
 
 ### Using System Prompts (any AI)
@@ -93,7 +99,7 @@ See [agdr-template.md](agdr-template.md) for the full template.
 |-------|-------------|---------|
 | `id` | Unique identifier | `AgDR-0001` |
 | `timestamp` | ISO-8601 with time | `2026-01-30T18:45:00Z` |
-| `agent` | Agent that made the decision | `claude-code`, `copilot`, `cursor` |
+| `agent` | Agent that made the decision | `claude-code`, `codex`, `copilot`, `cursor` |
 | `model` | Model identifier | `claude-opus-4-5-20251101` |
 | `trigger` | What initiated the decision | `user-prompt`, `hook`, `automation` |
 | `status` | Decision status | `proposed`, `executed`, `superseded` |
@@ -130,6 +136,7 @@ your-project/
 | Tool | Format | Location |
 |------|--------|----------|
 | **Claude Code** | `/decide` skill | [tools/claude-code/](tools/claude-code/) |
+| **Codex** | `SKILL.md` skill folder | [tools/codex/](tools/codex/) |
 | **Cursor** | `.cursor/rules/agdr.mdc` | [tools/cursor/](tools/cursor/) |
 | **GitHub Copilot** | `.github/copilot-instructions.md` + `.instructions.md` | [tools/copilot/](tools/copilot/) |
 | **Windsurf** | `.windsurf/rules/agdr.md` | [tools/windsurf/](tools/windsurf/) |
@@ -139,6 +146,10 @@ your-project/
 ### Claude Code
 
 The `/decide` skill triggers structured decision-making: [tools/claude-code/decide.md](tools/claude-code/decide.md)
+
+### Codex
+
+Codex skill folder for AgDR decision gating and file generation: [tools/codex/](tools/codex/)
 
 ### Cursor
 

--- a/tools/codex/README.md
+++ b/tools/codex/README.md
@@ -1,0 +1,48 @@
+# AgDR for Codex
+
+## Installation
+
+Copy the skill folder to your Codex skills directory:
+
+```bash
+mkdir -p "$CODEX_HOME/skills"
+cp -R tools/codex/agdr-decide "$CODEX_HOME/skills/agdr-decide"
+```
+
+If `CODEX_HOME` is not set, copy into your local Codex home:
+
+```bash
+mkdir -p ~/.codex/skills
+cp -R tools/codex/agdr-decide ~/.codex/skills/agdr-decide
+```
+
+## Usage
+
+Invoke the skill explicitly in a prompt:
+
+```text
+$agdr-decide decide REST vs GraphQL for the new API
+```
+
+You can also rely on automatic triggering when a prompt clearly asks for a technical choice.
+
+## What It Does
+
+When Codex is about to make a non-trivial technical decision, the skill will:
+
+1. Stop before implementing
+2. Compare at least 2 real options with pros/cons
+3. Create an AgDR file at `docs/agdr/AgDR-NNNN-slug.md`
+4. Then proceed with implementation
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `agdr-decide/SKILL.md` | Skill instructions for Codex decision gating and AgDR generation |
+
+## Learn More
+
+- [AgDR Repository](https://github.com/me2resh/agent-decision-record)
+- [Full Template](../../agdr-template.md)
+- [Examples](../../examples/)

--- a/tools/codex/agdr-decide/SKILL.md
+++ b/tools/codex/agdr-decide/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: agdr-decide
+description: Enforce Agent Decision Record (AgDR) workflow in Codex. Use when making a non-trivial technical decision such as selecting libraries/frameworks/tools, choosing implementation patterns, making architecture choices, or resolving explicit comparisons like "X vs Y". Analyze options first, document the decision in docs/agdr/AgDR-NNNN-slug.md, then implement.
+---
+
+# AgDR Decision Gate
+
+Follow this process before implementation whenever the decision is non-trivial.
+
+## 1. Parse the Decision Topic
+
+Extract the specific decision from the user request and restate it clearly.
+If ambiguous, ask one short clarifying question.
+
+## 2. Gather Decision Context
+
+Collect only context that influences the decision:
+
+- Problem to solve
+- Constraints (performance, cost, timeline, team familiarity, platform)
+- Relevant current codebase state
+
+Keep context concise (2-5 bullets).
+
+## 3. Compare Real Options
+
+Compare 2-4 realistic options in a table:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Option A | ... | ... |
+| Option B | ... | ... |
+
+Avoid strawman options.
+
+## 4. Make the Decision
+
+Pick one option and justify with a clear `because` clause.
+Acknowledge at least one tradeoff.
+
+## 5. Create the AgDR File
+
+Create `docs/agdr/AgDR-{NNNN}-{slug}.md` with zero-padded IDs.
+
+Determine `{NNNN}` by scanning existing files:
+
+```bash
+mkdir -p docs/agdr
+last="$(find docs/agdr -maxdepth 1 -name 'AgDR-*.md' 2>/dev/null | sed -E 's|.*AgDR-([0-9]+)-.*|\1|' | sort -n | tail -1)"
+if [ -z "$last" ]; then
+  next="0001"
+else
+  next="$(printf "%04d" "$((10#$last + 1))")"
+fi
+echo "$next"
+```
+
+Use this structure:
+
+```markdown
+---
+id: AgDR-{NNNN}
+timestamp: {YYYY-MM-DDTHH:MM:SSZ}
+agent: codex
+model: {model-id}
+session: {session-id-if-available}
+trigger: {user-prompt | hook | automation | self-initiated}
+status: {proposed | executed | superseded}
+---
+
+# {Short descriptive title}
+
+> In the context of {situation}, facing {concern}, I decided {decision} to achieve {goal}, accepting {tradeoff}.
+
+## Context
+- ...
+- ...
+
+## Options Considered
+| Option | Pros | Cons |
+|--------|------|------|
+| ... | ... | ... |
+
+## Decision
+Chosen: **{option}**, because {justification}.
+
+## Consequences
+- ...
+- ...
+- ...
+
+## Artifacts
+- {PR/commit/issue links if available}
+```
+
+Build a lowercase hyphenated slug from the title and keep it short.
+
+## 6. Continue Implementation
+
+After writing the AgDR, continue with the chosen implementation path.
+
+## Rules
+
+1. Always document non-trivial technical decisions before implementation.
+2. Require at least 2 real options.
+3. Require the Y-statement.
+4. Keep context minimal and decision-focused.
+5. Skip AgDR only for trivial choices or strict existing project conventions.

--- a/tools/system-prompts/README.md
+++ b/tools/system-prompts/README.md
@@ -50,6 +50,7 @@ Create a markdown file at docs/agdr/AgDR-{NNNN}-{slug}.md with:
 For tools with native rule systems, use the dedicated integrations instead:
 
 - [Claude Code](../claude-code/) — `/decide` slash command
+- [Codex](../codex/) — `SKILL.md` skill folder (`agdr-decide`)
 - [Cursor](../cursor/) — `.cursor/rules/agdr.mdc`
 - [GitHub Copilot](../copilot/) — `.github/copilot-instructions.md`
 - [Windsurf](../windsurf/) — `.windsurf/rules/agdr.md`


### PR DESCRIPTION
- added `tools/codex/agdr-decide/SKILL.md` to enforce AgDR decision workflow in Codex
- added `tools/codex/README.md` with install and usage instructions
- updated root `README.md` to include Codex in quick start and integrations
- updated `tools/system-prompts/README.md` to list Codex as a dedicated integration