### PR TITLE
ci(#17): cap all workflow job timeouts at 10 minutes

### DIFF
--- a/.github/workflows/changelog-lockstep.yml
+++ b/.github/workflows/changelog-lockstep.yml
@@ -17,6 +17,7 @@ jobs:
   lockstep:
     name: Manifest version <-> CHANGELOG.md entry
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -20,6 +20,7 @@ jobs:
   lychee:
     name: Check markdown links
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/validate-agdr.yml
+++ b/.github/workflows/validate-agdr.yml
@@ -19,6 +19,7 @@ jobs:
   validate:
     name: Validate examples/ against schema/agdr.schema.json
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
<!-- agdr: not-applicable -->
_AgDR escape hatch used deliberately: mechanical org-mandated safety default (uniform 10-min cap, no alternatives weighed) — orchestrator pre-authorized, consistent with the sibling portfolio PRs._

## Summary
- **Caps every workflow job at 10 minutes** — a hung job now dies in 10 minutes instead of burning the 6-hour Actions ceiling; normal runs unaffected
- Part of the portfolio-wide timeout hardening (all repos, 2026-07-12)

## Testing
1. YAML parse verified locally on all workflow files
2. CI on this PR is itself the functional test — all jobs should run and pass under the cap

3 of 3 jobs capped (changelog-lockstep.yml, link-check.yml, validate-agdr.yml). 0 skipped — no reusable-workflow (`uses:` at job level) jobs exist in this repo.

Closes #17

## Glossary
| Term | Definition |
|------|------------|
| timeout-minutes | GitHub Actions per-job wall-clock cap; job is killed when exceeded (default 360 min) |
| Actions ceiling | GitHub's 6-hour maximum job runtime — what an uncapped hung job burns |