### PR TITLE
docs(#12): add Code of Conduct and Security Policy

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement via a GitHub issue
+or by contacting the maintainers directly. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Scope
+
+This repository holds the **Agent Decision Record (AgDR) specification**, its
+templates, and the reference `tools/` integrations. It is documentation and
+tooling — there is no hosted service. The realistic security surface is:
+
+- The `tools/` integrations (scripts/config that run in a contributor's or
+  adopter's environment)
+- Template or spec content that, if maliciously altered, could induce an
+  automated agent to take an unsafe action
+- Supply-chain concerns in any dependencies the tooling pulls in
+
+## Supported Versions
+
+Security fixes are applied to the latest tagged release and to `main`. Older
+tags are not back-patched — upgrade to the latest version.
+
+| Version | Supported |
+|---------|-----------|
+| latest release / `main` | ✅ |
+| older tags | ❌ |
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for a security vulnerability.**
+
+Report it privately through GitHub's
+[private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+on this repository (Security → Report a vulnerability), or by contacting the
+maintainer directly.
+
+When reporting, please include:
+
+- A description of the issue and its potential impact
+- Steps to reproduce (a proof of concept if you have one)
+- The affected file(s), tool integration, or version
+
+## What to Expect
+
+- **Acknowledgement** within 5 business days.
+- An initial assessment and severity triage shortly after.
+- Coordinated disclosure once a fix is available — we will credit reporters who
+  wish to be named.
+
+Thank you for helping keep the AgDR ecosystem and its adopters safe.


### PR DESCRIPTION
## Summary

- **Adds `CODE_OF_CONDUCT.md`** — the standard Contributor Covenant v2.1, unmodified. It gives the project the community-health file GitHub surfaces in the repo sidebar and the "Community Standards" checklist, and sets clear expectations + an enforcement ladder for an open-source spec repo that takes outside contributions.
- **Adds `SECURITY.md`** — a scoped vulnerability-disclosure policy tailored to *this* repo (a spec + `tools/` integrations, not a hosted service): it names the real surface (the tool integrations, template/spec tampering, supply-chain), routes reports through GitHub private vulnerability reporting rather than public issues, and sets response-time expectations.

Both are conventional, review-light additions — the value is that a contributor now has a stated code of conduct and a safe, private channel for security reports instead of a public issue.

## Testing

1. Confirm `CODE_OF_CONDUCT.md` and `SECURITY.md` render on GitHub and appear under Insights → Community Standards.
2. Confirm the SECURITY.md reporting link points at this repo's private-reporting flow.

Closes #12

---

## Glossary

| Term | Definition |
|------|------------|
| Contributor Covenant | A widely-adopted open-source code-of-conduct text (v2.1 here) that projects use verbatim so contributors know the behavioural standard. |
| Community Standards | GitHub's Insights checklist that flags whether a repo has a README, CoC, contributing guide, license, etc. |
| Private vulnerability reporting | GitHub's built-in channel for disclosing a security issue privately to maintainers instead of in a public issue. |
| Security surface | The set of places a vulnerability could realistically live — here, the `tools/` integrations, spec/template tampering, and dependencies. |
