### PR TITLE
docs(#13): add [Bug] issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report something broken or behaving incorrectly in the AgDR spec, templates, or a tools/ integration
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. For a **question or proposed change** to [SPEC.md](../../SPEC.md), the templates, or a `tools/` integration, use the **Spec question or gap** form instead. Please don't paste secrets or private data.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug — what went wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps (and a minimal example or command) that trigger the bug.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: input
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part? e.g. SPEC.md, a specific template, a `tools/` integration, or the CLI.
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Version / environment
+      description: Repo version or commit SHA, OS, and any relevant tool/integration versions.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or error output
+      description: Paste any relevant error output — it will be formatted as code automatically.
+      render: shell
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- **Adds a `[Bug]` issue form** at `.github/ISSUE_TEMPLATE/bug-report.yml` — the one report type the repo was missing (it already had `spec-question.yml` and `example-contribution.yml`). Reporters now get a structured bug path instead of a blank issue, and maintainers get consistent, triage-ready reports.
- **Matches the repo's existing YAML issue-form style** — same schema as `spec-question.yml` (not a markdown template): a `[Bug] ` title prefix, a `bug` label auto-applied, an intro that routes *spec questions* to the other form, and required "what happened / expected / steps to reproduce" fields plus optional affected-area, environment, and a `render: shell` logs field.
- **Scoped to this repo's reality** — the affected-area hint names SPEC.md, templates, `tools/` integrations, and the CLI (the real surfaces), and the intro reminds reporters not to paste secrets.

## Testing

1. On a branch, open a new issue → the "Bug report" form should appear alongside the existing forms, with the `bug` label and `[Bug] ` prefix pre-filled.
2. Confirm the three required fields block submission when empty and the logs field renders as a code block.

Closes #13

---

## Glossary

| Term | Definition |
|------|------------|
| Issue form | GitHub's structured (YAML-defined) issue template that renders labelled fields with validation, instead of a free-form markdown body. |
| `render: shell` | An issue-form field option that formats the entered text as a fenced code block — used here for pasted logs/errors. |
| Auto-applied label | The `labels:` key on the form attaches `bug` to every issue opened through it, so triage/filtering works without manual tagging. |
