### PR TITLE
docs(#14): add llms.txt machine-readable surface

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,27 @@
+# Agent Decision Record (AgDR)
+
+> A standard for documenting technical decisions made by AI coding agents — an ADR variant for the age of AI-assisted development. Each AgDR captures the options an agent considered, the decision it made, and the rationale, in a compact format that both humans and agents can read and generate.
+
+## Specification
+
+- [Specification (SPEC.md)](https://github.com/me2resh/agent-decision-record/blob/main/SPEC.md): the AgDR format definition — required fields, semantics, and conventions.
+- [JSON schema](https://github.com/me2resh/agent-decision-record/blob/main/schema/agdr.schema.json): the machine-validatable schema for a single AgDR record.
+
+## Templates
+
+- [Full template](https://github.com/me2resh/agent-decision-record/blob/main/agdr-template.md): the complete AgDR template.
+- [Short template](https://github.com/me2resh/agent-decision-record/blob/main/agdr-template-short.md): the compact one-screen variant.
+
+## Examples
+
+- [Example AgDRs](https://github.com/me2resh/agent-decision-record/tree/main/examples): six worked decision records — auth-provider choice, DynamoDB partition-key design, data-migration strategy, MVVM/clean architecture, a GitHub Actions release workflow, and an image-loading library choice.
+
+## Tool integrations
+
+- [tools/](https://github.com/me2resh/agent-decision-record/tree/main/tools): drop-in integrations that get an agent writing AgDRs in your workflow — Claude Code, Codex, Copilot, Cursor, Windsurf, git hooks, and system prompts.
+
+## Optional
+
+- [README](https://github.com/me2resh/agent-decision-record/blob/main/README.md): human-facing overview and quick start.
+- [Contributing guide](https://github.com/me2resh/agent-decision-record/blob/main/CONTRIBUTING.md): how to propose changes and add tool integrations.
+- [Changelog](https://github.com/me2resh/agent-decision-record/blob/main/CHANGELOG.md): version history.


### PR DESCRIPTION
## Summary

- **Adds `llms.txt` at the repo root** — an [llmstxt.org](https://llmstxt.org)-format map of the spec so an agent (or a human's assistant) landing here gets a bounded, machine-readable index instead of having to crawl the tree. Fitting, given AgDR is itself a standard *about* AI agents.
- **Every link points at a file/dir that actually exists** — SPEC.md, `schema/agdr.schema.json`, both templates, the `examples/` set, and the `tools/` integrations — verified against the repo tree, so there are no dead links for a crawler to trip on.
- **Structured for skimming** — a one-paragraph description blockquote, then sections (Specification, Templates, Examples, Tool integrations) with the secondary material under `## Optional`, per the llms.txt convention.

## Not included here (needs repo-admin)

The other half of #14 — **setting the GitHub repo homepage field** — requires admin on the repo, which the PR-authoring account doesn't have (it has write). The repo owner needs to set it in Settings → General → Website. This PR therefore uses `Refs #14` (not `Closes`); close #14 once the homepage is set. The optional README JSON-LD is left as a future enhancement.

## Testing

1. Confirm `llms.txt` renders at the repo root and every link resolves (SPEC, schema, templates, examples, tools).

Refs #14

---

## Glossary

| Term | Definition |
|------|------------|
| `llms.txt` | An [llmstxt.org](https://llmstxt.org) convention: a root-level, machine-readable file that gives LLMs/agents a curated, link-based map of a project instead of forcing them to crawl it. |
| Repo homepage | GitHub's "Website" field (Settings → General) shown at the top of the repo — the machine/human landing pointer #14 also asks to set (admin-only, deferred here). |
| Citation grounding | Giving an AI a canonical, linkable source for a fact so its answers can cite the real spec rather than paraphrase — the motivation behind a machine-readable surface. |
