### PR TITLE
docs(#11): pin the adoption path to a tagged release

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ AgDR is a plain standard, not a product — **you don't need ApexYard or any fra
 2. **The schema** — [`schema/agdr.schema.json`](schema/agdr.schema.json), so frontmatter is machine-checkable.
 3. **The check** — vendor [`scripts/validate-agdr.js`](scripts/validate-agdr.js) (or the [`validate-agdr.yml`](.github/workflows/validate-agdr.yml) workflow) so CI rejects malformed records.
 
+**Pin a version.** Those three files are a snapshot of a versioned standard, so take them from a tagged [release](https://github.com/me2resh/agent-decision-record/releases) rather than from `main` — otherwise a later spec change quietly moves the bar your CI enforces, on a commit you never chose:
+
+```bash
+git clone --branch v1.2.0 --depth 1 https://github.com/me2resh/agent-decision-record.git
+```
+
+That tag is also what you cite when you record adopting AgDR as an AgDR of your own. [CHANGELOG.md](CHANGELOG.md) lists what changed between versions.
+
 Or wire it into your agent directly:
 
 ### Install as Claude Code Plugin

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ AgDR is a plain standard, not a product — **you don't need ApexYard or any fra
 2. **The schema** — [`schema/agdr.schema.json`](schema/agdr.schema.json), so frontmatter is machine-checkable.
 3. **The check** — vendor [`scripts/validate-agdr.js`](scripts/validate-agdr.js) (or the [`validate-agdr.yml`](.github/workflows/validate-agdr.yml) workflow) so CI rejects malformed records.
 
-**Pin a version.** Those three files are a snapshot of a versioned standard, so take them from a tagged [release](https://github.com/me2resh/agent-decision-record/releases) rather than from `main` — otherwise a later spec change quietly moves the bar your CI enforces, on a commit you never chose:
+**Pin a version.** Those three files are a snapshot of a versioned standard, so take them from a tagged [release](https://github.com/me2resh/agent-decision-record/releases) rather than from `main` — otherwise nothing records *which* version you adopted, and the next person to re-vendor quietly picks up a different one:
 
 ```bash
 git clone --branch v1.2.0 --depth 1 https://github.com/me2resh/agent-decision-record.git


### PR DESCRIPTION
## Summary

- **Adopters currently copy the standard off a moving target.** The 5-minute adoption path tells you to vendor three files — the template, `schema/agdr.schema.json`, and `scripts/validate-agdr.js` — but never says *which version* of them. None of the three self-identifies: the schema's `$id` is unversioned, the validator carries no version constant, the template has no version field. So nothing records what you adopted, and the next person to re-vendor quietly lands on a different revision. This adds a "Pin a version" step pointing at a tagged release instead.
- **It links the releases page and CHANGELOG at the decision point**, so someone choosing a version can see the delta between them without leaving the quickstart.
- **It ties the pin back to the standard's own philosophy** — the tag is what you cite when you record adopting AgDR as an AgDR of your own.

Docs-only, eight added lines, no normative change: `SPEC.md` is untouched and the validator behaves identically.

## Type of change

- [x] Docs (`README.md`, `CONTRIBUTING.md`, etc.)

## Merge order — this PR depends on the release being published

The snippet runs `git clone --branch v1.2.0`, which fails until the tag is pushed. Worse, the paragraph links the **releases index**, which lists nothing to anonymous readers while the release is still a draft — so merging first ships a step titled "Pin a version" pointing at a page with no versions on it.

**Publish the v1.2.0 release before merging this.** The tag and Release are the other half of #11 and are staged as a draft; they are not in this diff, because a tag is not a reviewable artifact.

Two notes for whoever picks up the rest of #11:

- The release targets **`e4e1a4e`**, the current tip of `main` — not `7eca2d8`, which carries the same subject line ("docs: add llms.txt machine-readable surface") but is the pre-squash branch commit. It is not an ancestor of `main` and is missing `.github/ISSUE_TEMPLATE/bug-report.yml` from #20. Tagging it would have pinned v1.2.0 to an unreachable commit with incomplete content.
- The prose deliberately links the releases index rather than `/releases/tag/v1.2.0`. A direct tag URL 404s until publish, and the index needs no edit on future releases. The trade-off is the empty-index window described above.
- `v1.2.0` is a hardcoded string in the README that nothing currently watches — `check-changelog-lockstep.js` covers only the two manifests plus `CHANGELOG.md`. At the next version bump every check stays green while this section still says clone v1.2.0. Worth folding into the auto-release workflow #11 also asks for.

## Testing

1. Read the rendered "Adopt in 5 minutes" section — the pin step sits between the three-file list and the per-agent install instructions.
2. `link-check` (lychee): both links introduced here resolve. **The job is currently red on a pre-existing failure unrelated to this PR** — the `apexscript.com` adopters-table link, already on `main`, returned a connection failure (DNS/TCP, not an HTTP status). A re-run has been triggered to establish whether it is transient; if it persists it wants a separate fix, on the same "decorative, not worth gating CI on" reasoning `.lychee.toml` already applies to a third-party badge service.
3. After `v1.2.0` is pushed, `git clone --branch v1.2.0 --depth 1 https://github.com/me2resh/agent-decision-record.git` should succeed.

No change to `examples/`, `schema/`, `scripts/`, or `.claude-plugin/`, so `npm run validate` and the changelog-lockstep check are unaffected.

## Checklist

- [x] `npm run validate` passes (unaffected — no change to `examples/`, `schema/`, or `scripts/validate-agdr.js`)
- [x] `npm run validate:changelog` passes (unaffected — no manifest version bump)
- [x] Markdown links introduced by this PR resolve; the one failing link is pre-existing on `main` (see Testing)
- [x] Normative rules unchanged, so `SPEC.md` needs no update

## Glossary

| Term | Definition |
|------|------------|
| Pin (a version) | Depending on a fixed, named revision — here a git tag — instead of whatever a branch points at today, so the dependency cannot change under you. |
| Tag | An immutable git label on one commit. `v1.2.0` always means this exact tree, unlike `main`, which advances with every merge. |
| Squash-merge | Merging a PR by collapsing its commits into one new commit on the base branch. The original branch commits are never reachable from `main` — which is why `7eca2d8` and `e4e1a4e` are different SHAs for the same change. |
| Vendor (a file) | Copying a dependency's source into your own repo instead of installing it from a package registry. The zero-dependency adoption path for AgDR today. |
| lychee | The link checker run by `link-check.yml`; it fails the build on any markdown link that does not resolve. |

Refs #11